### PR TITLE
docs: add game starter asset mapping guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SentinelAi - Advanced AI automation and monitoring platform
 - [**Copilot Recommendations**](COPILOT_RECOMMENDATIONS.md) - AI integration strategies
 - [**Pull Request Template**](.github/PULL_REQUEST_TEMPLATE.md) - Standardized PR format
 - [**Audit Logs**](.audit-logs/README.md) - Audit logging documentation
+- [**Game Starter Mapping**](docs/game_starter_mapping.md) - Inventory of reusable repo assets and a minimal game-project rollout plan
 
 ## CI/CD Workflows
 

--- a/docs/game_starter_mapping.md
+++ b/docs/game_starter_mapping.md
@@ -9,8 +9,8 @@ This repository does not currently contain game content assets (sprites, texture
 - `ai-task-prioritization.sh`: weighted task scoring for backlog triage.
 - `multi-host-deployment.sh`: deployment preflight and host automation.
 - `sentinel_client_update.sh`: update workflow helper.
-- `ai-task-prioritization.sh`, `multi-host-deployment.sh`, and `cli-validation.sh` write audit-oriented outputs suitable for operational traceability.
 
+These automation scripts write audit-oriented outputs suitable for operational traceability.
 ### Documentation/process assets
 - `AUTOMATION.md`: runbooks and automation design context.
 - `COPILOT_RECOMMENDATIONS.md`: collaboration and AI-assist workflow guidance.

--- a/docs/game_starter_mapping.md
+++ b/docs/game_starter_mapping.md
@@ -32,7 +32,7 @@ To keep changes small and preserve current repo behavior, treat this as a planni
 
 ## Recommended first steps
 
-1. Keep existing automation scripts unchanged and use them as CI/CD and environment checks while game code is introduced incrementally.
+1. Use existing automation scripts as CI/CD and environment checks, customizing them (especially sentinel_client_update.sh and multi-host-deployment.sh) to point to your project's repository and endpoints.
 2. Add game assets in small batches with clear naming conventions.
 3. Add tests for asset integrity (for example, required files present per level).
 4. Keep deployment and validation scripts as the baseline guardrails while game runtime components are added.

--- a/docs/game_starter_mapping.md
+++ b/docs/game_starter_mapping.md
@@ -1,0 +1,38 @@
+# Game Starter Mapping (Using Existing Sentinel Assets)
+
+This repository does not currently contain game content assets (sprites, textures, audio, levels, shaders, or engine project files).
+
+## Existing assets you can reuse for a game project
+
+### Automation and quality assets
+- `cli-validation.sh`: environment and CLI prerequisite checks.
+- `ai-task-prioritization.sh`: weighted task scoring for backlog triage.
+- `multi-host-deployment.sh`: deployment preflight and host automation.
+- `sentinel_client_update.sh`: update workflow helper.
+- `ai-task-prioritization.sh`, `multi-host-deployment.sh`, and `cli-validation.sh` write audit-oriented outputs suitable for operational traceability.
+
+### Documentation/process assets
+- `AUTOMATION.md`: runbooks and automation design context.
+- `COPILOT_RECOMMENDATIONS.md`: collaboration and AI-assist workflow guidance.
+- `REVIEW.md`: review process reference.
+
+## Suggested minimal game-oriented layout (proposal only)
+
+To keep changes small and preserve current repo behavior, treat this as a planning map rather than an immediate restructure:
+
+- `assets/`
+  - `sprites/`
+  - `audio/`
+  - `levels/`
+- `game/`
+  - `core/`
+  - `systems/`
+- `tests/`
+  - `game/`
+
+## Recommended first steps
+
+1. Keep existing automation scripts unchanged and use them as CI/CD and environment checks while game code is introduced incrementally.
+2. Add game assets in small batches with clear naming conventions.
+3. Add tests for asset integrity (for example, required files present per level).
+4. Keep deployment and validation scripts as the baseline guardrails while game runtime components are added.


### PR DESCRIPTION
### Motivation
- Provide a lightweight planning map that inventories reusable repo assets and outlines minimal steps to introduce game content incrementally without changing repository structure or automation.

### Description
- Add `docs/game_starter_mapping.md` containing an inventory of existing automation/process assets, a suggested minimal game-oriented layout, and recommended first steps, and update `README.md` to link to the new guide.

### Testing
- Repro commands: `sed -n '1,220p' docs/game_starter_mapping.md` and `rg -n "Game Starter Mapping" README.md`.
- Automated test results: `pytest -q` discovered no tests in the repository (exit code 5), and `npm test` failed because `package.json` is not present so Node tests could not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935bc448c48325b7bfdd2e88b92f13)