### PR TITLE
msq-idler: add content pack, event schemas, 384-bin hashing, and bounded bandit policy

### DIFF
--- a/data/msq/content_pack_v1.json
+++ b/data/msq/content_pack_v1.json
@@ -1,0 +1,49 @@
+{
+  "pack_id": "PACK-MSQ-0001",
+  "version": "1.0.0",
+  "created_at": "2026-02-16T00:00:00Z",
+  "rulesets": [
+    {
+      "ruleset_id": "RS-MSQ-0001",
+      "name": "Lo Shu Idle",
+      "size": 3,
+      "target_sum": 15,
+      "tile_pool": { "min": 1, "max": 9, "mode": "unique_in_grid" },
+      "lines": "rows_cols_diagonals",
+      "allowed_moves": ["swap_adjacent", "rotate_row", "rotate_col", "lock_tile"],
+      "lock_rules": { "max_locks": 2, "lock_cost": 10, "unlock_cost": 5 },
+      "spawn_rules": { "spawn_mode": "refill_blanks", "spawn_count_per_tick": 1, "rng_profile_id": "RNG-PROFILE-DEFAULT" },
+      "scoring": {
+        "complete_line_bonus": 100,
+        "near_miss_bonus": 10,
+        "combo_multiplier": { "enabled": true, "window_sec": 8, "growth": 0.15 }
+      },
+      "idle": {
+        "tick_sec": 1,
+        "base_SE": 1.0,
+        "base_CE": 5.0,
+        "base_TN": 0.5,
+        "prox_scale": 7,
+        "blank_penalty": 0.6
+      },
+      "progression": {
+        "unlock_next_ruleset_at_level": 5,
+        "level_xp_curve": "linear",
+        "xp_per_complete_line": 1
+      }
+    }
+  ],
+  "rng_profiles": [
+    { "rng_profile_id": "RNG-PROFILE-DEFAULT", "description": "Uniform tile draws within tile_pool constraints.", "weights": "uniform" }
+  ],
+  "ai_tuning": {
+    "enabled": true,
+    "policy_id": "POLICY-BANDIT-0001",
+    "guardrails": {
+      "max_difficulty_step_per_session": 1,
+      "min_runs_before_personalization": 3,
+      "no_sensitive_inference": true,
+      "bounded_changes_only": true
+    }
+  }
+}

--- a/docs/msq_idler/README.md
+++ b/docs/msq_idler/README.md
@@ -1,0 +1,12 @@
+# Magic Square Idler (engine scaffolding)
+
+This folder defines the minimal audit-native scaffolding for a magic square idler game:
+- versioned content pack (rulesets)
+- deterministic state hashing + 384-bin routing
+- JSONL telemetry events
+- bounded per-player bandit policy (arm selection only)
+
+Non-goals:
+- no UI
+- no auto-patching or global rollout
+- no sensitive inference

--- a/schemas/msq_content_pack_v1.schema.json
+++ b/schemas/msq_content_pack_v1.schema.json
@@ -95,7 +95,7 @@
             "additionalProperties": false
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       }
     },
     "rng_profiles": {

--- a/schemas/msq_content_pack_v1.schema.json
+++ b/schemas/msq_content_pack_v1.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kennecodex.dev/schemas/msq_content_pack_v1.schema.json",
+  "title": "MagicSquare Content Pack v1",
+  "type": "object",
+  "required": ["pack_id", "version", "created_at", "rulesets", "rng_profiles", "ai_tuning"],
+  "properties": {
+    "pack_id": { "type": "string" },
+    "version": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "rulesets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["ruleset_id", "name", "size", "target_sum", "tile_pool", "lines", "allowed_moves", "spawn_rules", "scoring", "idle", "progression"],
+        "properties": {
+          "ruleset_id": { "type": "string" },
+          "name": { "type": "string" },
+          "size": { "type": "integer", "minimum": 3, "maximum": 9 },
+          "target_sum": { "type": "integer" },
+          "tile_pool": {
+            "type": "object",
+            "required": ["min", "max", "mode"],
+            "properties": {
+              "min": { "type": "integer" },
+              "max": { "type": "integer" },
+              "mode": { "type": "string", "enum": ["unique_in_grid", "with_replacement"] }
+            },
+            "additionalProperties": false
+          },
+          "lines": { "type": "string", "enum": ["rows_cols_diagonals", "rows_cols"] },
+          "allowed_moves": {
+            "type": "array",
+            "items": { "type": "string", "enum": ["swap_adjacent", "rotate_row", "rotate_col", "lock_tile"] }
+          },
+          "lock_rules": {
+            "type": "object",
+            "properties": {
+              "max_locks": { "type": "integer", "minimum": 0, "maximum": 9 },
+              "lock_cost": { "type": "integer", "minimum": 0 },
+              "unlock_cost": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "spawn_rules": {
+            "type": "object",
+            "required": ["spawn_mode", "spawn_count_per_tick", "rng_profile_id"],
+            "properties": {
+              "spawn_mode": { "type": "string", "enum": ["refill_blanks"] },
+              "spawn_count_per_tick": { "type": "integer", "minimum": 0, "maximum": 9 },
+              "rng_profile_id": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "scoring": {
+            "type": "object",
+            "required": ["complete_line_bonus", "near_miss_bonus", "combo_multiplier"],
+            "properties": {
+              "complete_line_bonus": { "type": "integer", "minimum": 0 },
+              "near_miss_bonus": { "type": "integer", "minimum": 0 },
+              "combo_multiplier": {
+                "type": "object",
+                "required": ["enabled", "window_sec", "growth"],
+                "properties": {
+                  "enabled": { "type": "boolean" },
+                  "window_sec": { "type": "integer", "minimum": 1 },
+                  "growth": { "type": "number", "minimum": 0 }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "idle": {
+            "type": "object",
+            "required": ["tick_sec", "base_SE", "base_CE", "base_TN", "prox_scale", "blank_penalty"],
+            "properties": {
+              "tick_sec": { "type": "integer", "minimum": 1, "maximum": 60 },
+              "base_SE": { "type": "number", "minimum": 0 },
+              "base_CE": { "type": "number", "minimum": 0 },
+              "base_TN": { "type": "number", "minimum": 0 },
+              "prox_scale": { "type": "integer", "minimum": 1 },
+              "blank_penalty": { "type": "number", "minimum": 0, "maximum": 1 }
+            },
+            "additionalProperties": false
+          },
+          "progression": {
+            "type": "object",
+            "required": ["unlock_next_ruleset_at_level", "level_xp_curve", "xp_per_complete_line"],
+            "properties": {
+              "unlock_next_ruleset_at_level": { "type": "integer", "minimum": 1 },
+              "level_xp_curve": { "type": "string", "enum": ["linear"] },
+              "xp_per_complete_line": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "rng_profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["rng_profile_id", "description", "weights"],
+        "properties": {
+          "rng_profile_id": { "type": "string" },
+          "description": { "type": "string" },
+          "weights": { "type": "string", "enum": ["uniform"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "ai_tuning": {
+      "type": "object",
+      "required": ["enabled", "policy_id", "guardrails"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "policy_id": { "type": "string" },
+        "guardrails": {
+          "type": "object",
+          "required": ["max_difficulty_step_per_session", "min_runs_before_personalization", "no_sensitive_inference", "bounded_changes_only"],
+          "properties": {
+            "max_difficulty_step_per_session": { "type": "integer", "minimum": 0, "maximum": 3 },
+            "min_runs_before_personalization": { "type": "integer", "minimum": 0, "maximum": 20 },
+            "no_sensitive_inference": { "type": "boolean" },
+            "bounded_changes_only": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/msq_content_pack_v1.schema.json
+++ b/schemas/msq_content_pack_v1.schema.json
@@ -40,7 +40,8 @@
               "max_locks": { "type": "integer", "minimum": 0, "maximum": 9 },
               "lock_cost": { "type": "integer", "minimum": 0 },
               "unlock_cost": { "type": "integer", "minimum": 0 }
-            }
+            },
+            "additionalProperties": false
           },
           "spawn_rules": {
             "type": "object",

--- a/schemas/msq_event_v1.schema.json
+++ b/schemas/msq_event_v1.schema.json
@@ -45,5 +45,5 @@
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/schemas/msq_event_v1.schema.json
+++ b/schemas/msq_event_v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kennecodex.dev/schemas/msq_event_v1.schema.json",
+  "title": "MagicSquare Telemetry Event v1 (JSONL)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "created_at",
+    "player_id",
+    "session_id",
+    "event_type",
+    "ruleset_id",
+    "state_id",
+    "bin_384"
+  ],
+  "properties": {
+    "schema_version": { "const": "msq_event_v1" },
+    "event_id": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "player_id": { "type": "string" },
+    "session_id": { "type": "string" },
+    "event_type": {
+      "type": "string",
+      "enum": ["session_start", "move", "line_complete", "hint_used", "session_end"]
+    },
+    "ruleset_id": { "type": "string" },
+    "state_id": { "type": "string" },
+    "bin_384": { "type": "integer", "minimum": 0, "maximum": 383 },
+
+    "move": {
+      "type": ["object", "null"],
+      "properties": {
+        "move_type": { "type": "string" },
+        "details": { "type": "object" }
+      }
+    },
+    "metrics": {
+      "type": ["object", "null"],
+      "properties": {
+        "time_in_node_sec": { "type": "number", "minimum": 0 },
+        "attempt_count": { "type": "integer", "minimum": 0 },
+        "near_miss_count": { "type": "integer", "minimum": 0 },
+        "lines_completed": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_msq_state.py
+++ b/tests/test_msq_state.py
@@ -1,0 +1,19 @@
+from tools.msq_state import MSQState, canonical_string, state_id_and_bin
+
+
+def test_state_hash_stable():
+    st = MSQState(
+        size=3,
+        target_sum=15,
+        ruleset_id="RS-MSQ-0001",
+        tiles=[8, 1, 6, 3, 5, 7, 4, 9, 2],
+        locks=[False] * 9,
+    )
+    c1 = canonical_string(st)
+    c2 = canonical_string(st)
+    assert c1 == c2
+    hid1, b1 = state_id_and_bin(st)
+    hid2, b2 = state_id_and_bin(st)
+    assert hid1 == hid2
+    assert b1 == b2
+    assert 0 <= b1 < 384

--- a/tools/msq_bandit_policy.py
+++ b/tools/msq_bandit_policy.py
@@ -37,7 +37,10 @@ DEFAULT_ARMS = [
 def _load_json(path: Path) -> Optional[Dict[str, Any]]:
     if not path.exists():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
 
 
 def _save_json(path: Path, obj: Dict[str, Any]) -> None:

--- a/tools/msq_bandit_policy.py
+++ b/tools/msq_bandit_policy.py
@@ -80,10 +80,10 @@ def update_arm(state: PlayerPolicyState, arm_id: str, success: bool) -> None:
 
 
 def arm_delta(arm_id: str) -> Dict[str, Any]:
-    for a in DEFAULT_ARMS:
-        if a["arm_id"] == arm_id:
-            return a["delta"]
-    raise ValueError(f"Unknown arm_id: {arm_id}")
+    arm = DEFAULT_ARMS_MAP.get(arm_id)
+    if arm is None:
+        raise ValueError(f"Unknown arm_id: {arm_id}")
+    return arm["delta"]
 
 
 def load_or_init_player_state(path: Path, player_id: str) -> PlayerPolicyState:

--- a/tools/msq_bandit_policy.py
+++ b/tools/msq_bandit_policy.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Bounded, per-player Thompson sampling over a small set of "arms".
+# This only SELECTS an arm; it does not auto-apply global patches.
+
+
+@dataclass
+class ArmState:
+    arm_id: str
+    alpha: float = 1.0  # Beta prior
+    beta: float = 1.0
+
+
+@dataclass
+class PlayerPolicyState:
+    player_id: str
+    runs_seen: int
+    arms: List[ArmState]
+
+
+DEFAULT_ARMS = [
+    # Minimal knob deltas; clients can interpret these into config tweaks.
+    {"arm_id": "A_BASELINE", "delta": {}},
+    {"arm_id": "B_MORE_SPAWNS", "delta": {"spawn_count_per_tick": +1}},
+    {"arm_id": "C_MORE_HINTS", "delta": {"hint_after_fails": 2}},
+    {"arm_id": "D_MORE_LOCKS", "delta": {"max_locks": +1}},
+    {"arm_id": "E_IDLE_BOOST", "delta": {"base_SE_mult": 1.1, "base_CE_mult": 1.05}},
+]
+
+
+def _load_json(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_json(path: Path, obj: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def init_player(player_id: str) -> PlayerPolicyState:
+    arms = [ArmState(a["arm_id"]) for a in DEFAULT_ARMS]
+    return PlayerPolicyState(player_id=player_id, runs_seen=0, arms=arms)
+
+
+def choose_arm(state: PlayerPolicyState, seed: Optional[int] = None) -> str:
+    rng = random.Random(seed)
+    best_arm = None
+    best_sample = -1.0
+    for arm in state.arms:
+        # Thompson sample from Beta(alpha, beta)
+        sample = rng.betavariate(arm.alpha, arm.beta)
+        if sample > best_sample:
+            best_sample = sample
+            best_arm = arm.arm_id
+    assert best_arm is not None
+    return best_arm
+
+
+def update_arm(state: PlayerPolicyState, arm_id: str, success: bool) -> None:
+    for arm in state.arms:
+        if arm.arm_id == arm_id:
+            if success:
+                arm.alpha += 1.0
+            else:
+                arm.beta += 1.0
+            state.runs_seen += 1
+            return
+    raise ValueError(f"Unknown arm_id: {arm_id}")
+
+
+def arm_delta(arm_id: str) -> Dict[str, Any]:
+    for a in DEFAULT_ARMS:
+        if a["arm_id"] == arm_id:
+            return a["delta"]
+    raise ValueError(f"Unknown arm_id: {arm_id}")
+
+
+def load_or_init_player_state(path: Path, player_id: str) -> PlayerPolicyState:
+    obj = _load_json(path)
+    if not obj:
+        return init_player(player_id)
+
+    arms = [ArmState(**a) for a in obj["arms"]]
+    return PlayerPolicyState(player_id=obj["player_id"], runs_seen=obj["runs_seen"], arms=arms)
+
+
+def save_player_state(path: Path, state: PlayerPolicyState) -> None:
+    _save_json(path, asdict(state))

--- a/tools/msq_demo_run.py
+++ b/tools/msq_demo_run.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.msq_bandit_policy import (
+    arm_delta,
+    choose_arm,
+    load_or_init_player_state,
+    save_player_state,
+    update_arm,
+)
+from tools.msq_state import MSQState, state_id_and_bin
+from tools.msq_telemetry import append_jsonl, new_event
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--player-id", default="P-DEMO")
+    p.add_argument("--ruleset-id", default="RS-MSQ-0001")
+    p.add_argument("--target-sum", type=int, default=15)
+    p.add_argument("--policy-path", default="audit/msq/policy/player_P-DEMO.json")
+    p.add_argument("--events", default="audit/msq/events.jsonl")
+    p.add_argument("--seed", type=int, default=123)
+    p.add_argument("--success", action="store_true", help="Mark session as success to update bandit")
+    args = p.parse_args()
+
+    session_id = f"S-{uuid.uuid4().hex[:12].upper()}"
+
+    # A dummy starting state (Lo Shu solved) for demo only.
+    tiles = [8, 1, 6, 3, 5, 7, 4, 9, 2]
+    locks = [False] * 9
+    st = MSQState(
+        size=3,
+        target_sum=args.target_sum,
+        ruleset_id=args.ruleset_id,
+        tiles=tiles,
+        locks=locks,
+    )
+    sid, b = state_id_and_bin(st)
+
+    policy_path = Path(args.policy_path)
+    events_path = Path(args.events)
+
+    pol = load_or_init_player_state(policy_path, args.player_id)
+    arm = choose_arm(pol, seed=args.seed)
+    delta = arm_delta(arm)
+
+    append_jsonl(
+        events_path,
+        new_event(
+            args.player_id,
+            session_id,
+            "session_start",
+            args.ruleset_id,
+            sid,
+            b,
+            metrics={"arm": arm, "delta": delta},
+        ),
+    )
+    append_jsonl(
+        events_path,
+        new_event(
+            args.player_id,
+            session_id,
+            "session_end",
+            args.ruleset_id,
+            sid,
+            b,
+            metrics={"success": bool(args.success)},
+        ),
+    )
+
+    update_arm(pol, arm, success=bool(args.success))
+    save_player_state(policy_path, pol)
+
+    print(
+        json.dumps(
+            {
+                "player_id": args.player_id,
+                "session_id": session_id,
+                "chosen_arm": arm,
+                "delta": delta,
+                "state_id": sid,
+                "bin_384": b,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/msq_state.py
+++ b/tools/msq_state.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import hashlib
+import unicodedata
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+DEFAULT_N_BINS = 384
+
+
+def _norm(s: str) -> str:
+    return unicodedata.normalize("NFKC", s.strip())
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class MSQState:
+    size: int
+    target_sum: int
+    ruleset_id: str
+    tiles: List[Optional[int]]  # row-major, None for blank
+    locks: List[bool]  # same length as tiles
+
+    def __post_init__(self):
+        n = self.size * self.size
+        if len(self.tiles) != n:
+            raise ValueError(f"tiles must have length {n}")
+        if len(self.locks) != n:
+            raise ValueError(f"locks must have length {n}")
+
+
+def canonical_string(state: MSQState, version: str = "v1") -> str:
+    # MSQ|v1|N=3|T=15|R=RS-MSQ-0001|G=8,1,6,3,5,7,4,9,2|L=000000000
+    g = []
+    for t in state.tiles:
+        g.append("_" if t is None else str(int(t)))
+    l = "".join("1" if b else "0" for b in state.locks)
+    return _norm(
+        f"MSQ|{version}|N={state.size}|T={state.target_sum}|R={state.ruleset_id}|G={','.join(g)}|L={l}"
+    )
+
+
+def state_id_and_bin(state: MSQState, n_bins: int = DEFAULT_N_BINS) -> Tuple[str, int]:
+    canon = canonical_string(state)
+    hid = sha256_hex(canon)
+    b = int(hid, 16) % n_bins
+    return hid, b

--- a/tools/msq_telemetry.py
+++ b/tools/msq_telemetry.py
@@ -18,8 +18,12 @@ def ensure_parent_dir(path: Path) -> None:
 
 def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
     ensure_parent_dir(path)
-    with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    # Use a lock file to prevent concurrent write issues.
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    from filelock import FileLock
+    with FileLock(lock_path):
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
 @dataclass

--- a/tools/msq_telemetry.py
+++ b/tools/msq_telemetry.py
@@ -65,3 +65,79 @@ def new_event(
         metrics=metrics,
     )
     return asdict(ev)
+
+
+def _self_test() -> None:
+    """
+    Lightweight self-test to detect schema drift and JSONL append regressions.
+
+    This function is intended to be run via:
+
+        python -m tools.msq_telemetry
+
+    or:
+
+        python tools/msq_telemetry.py
+    """
+    # Validate event shape and field formats.
+    event = new_event(
+        player_id="player-1",
+        session_id="session-1",
+        event_type="test_event",
+        ruleset_id="ruleset-1",
+        state_id="state-1",
+        bin_384=0,
+    )
+
+    required_fields = {
+        "schema_version",
+        "event_id",
+        "created_at",
+        "player_id",
+        "session_id",
+        "event_type",
+        "ruleset_id",
+        "state_id",
+        "bin_384",
+    }
+    missing = required_fields.difference(event.keys())
+    assert not missing, f"MSQEvent missing required fields: {missing}"
+
+    # Check stable schema/version and ID prefixes.
+    assert isinstance(event["schema_version"], str), "schema_version must be a string"
+    assert event["schema_version"].startswith(
+        "msq_event_v"
+    ), f"Unexpected schema_version prefix: {event['schema_version']!r}"
+
+    assert isinstance(event["event_id"], str), "event_id must be a string"
+    assert event["event_id"].startswith(
+        "EV-"
+    ), f"Unexpected event_id prefix: {event['event_id']!r}"
+    assert len(event["event_id"]) > 3, "event_id appears too short"
+
+    # Validate ISO-8601 datetime format.
+    try:
+        datetime.fromisoformat(event["created_at"])
+    except Exception as exc:  # pragma: no cover - defensive
+        raise AssertionError(
+            f"created_at is not a valid ISO-8601 datetime: {event['created_at']!r}"
+        ) from exc
+
+    # Validate JSONL append behavior.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "events.jsonl"
+        append_jsonl(tmp_path, event)
+
+        contents = tmp_path.read_text(encoding="utf-8").splitlines()
+        assert len(contents) == 1, f"Expected 1 JSONL line, found {len(contents)}"
+
+        loaded = json.loads(contents[0])
+        assert (
+            loaded == event
+        ), "Round-tripped JSONL record does not match original event"
+
+
+if __name__ == "__main__":  # pragma: no cover - optional runtime self-check
+    _self_test()

--- a/tools/msq_telemetry.py
+++ b/tools/msq_telemetry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    ensure_parent_dir(path)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+@dataclass
+class MSQEvent:
+    schema_version: str
+    event_id: str
+    created_at: str
+    player_id: str
+    session_id: str
+    event_type: str
+    ruleset_id: str
+    state_id: str
+    bin_384: int
+    move: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, Any]] = None
+
+
+def new_event(
+    player_id: str,
+    session_id: str,
+    event_type: str,
+    ruleset_id: str,
+    state_id: str,
+    bin_384: int,
+    move: Optional[Dict[str, Any]] = None,
+    metrics: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    ev = MSQEvent(
+        schema_version="msq_event_v1",
+        event_id=f"EV-{uuid.uuid4().hex[:16].upper()}",
+        created_at=utc_now_iso(),
+        player_id=player_id,
+        session_id=session_id,
+        event_type=event_type,
+        ruleset_id=ruleset_id,
+        state_id=state_id,
+        bin_384=bin_384,
+        move=move,
+        metrics=metrics,
+    )
+    return asdict(ev)

--- a/tools/msq_telemetry.py
+++ b/tools/msq_telemetry.py
@@ -11,22 +11,48 @@ from typing import Any, Dict, Optional
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
-
-def ensure_parent_dir(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
-def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
-    ensure_parent_dir(path)
-    # Use a lock file to prevent concurrent write issues.
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    from filelock import FileLock
-    with FileLock(lock_path):
-        with path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+from tools.bin_harness_384 import append_jsonl, ensure_parent_dir, utc_now_iso
 
 
 @dataclass
+class MSQEvent:
+    schema_version: str
+    event_id: str
+    created_at: str
+    player_id: str
+    session_id: str
+    event_type: str
+    ruleset_id: str
+    state_id: str
+    bin_384: int
+    move: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, Any]] = None
+
+
+def new_event(
+    player_id: str,
+    session_id: str,
+    event_type: str,
+    ruleset_id: str,
+    state_id: str,
+    bin_384: int,
+    move: Optional[Dict[str, Any]] = None,
+    metrics: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    ev = MSQEvent(
+        schema_version="msq_event_v1",
+        event_id=f"EV-{uuid.uuid4().hex[:16].upper()}",
+        created_at=utc_now_iso(),
+        player_id=player_id,
+        session_id=session_id,
+        event_type=event_type,
+        ruleset_id=ruleset_id,
+        state_id=state_id,
+        bin_384=bin_384,
+        move=move,
+        metrics=metrics,
+    )
+    return asdict(ev)
 class MSQEvent:
     schema_version: str
     event_id: str


### PR DESCRIPTION
### Motivation
- Provide minimal, auditable engine scaffolding for a Magic Square Idler including versioned content and bounded personalization primitives.
- Ensure deterministic state identity and routing by canonicalizing game state and mapping SHA-256 to a fixed 384-bin space for telemetry/partitioning.
- Keep runtime effects local and reviewable by using append-only JSONL telemetry and an arm-selection-only bandit (no automatic global patches).

### Description
- Added JSON Schema files `schemas/msq_content_pack_v1.schema.json` and `schemas/msq_event_v1.schema.json` to define content packs and telemetry event shapes. 
- Added a sample content pack `data/msq/content_pack_v1.json` with a Lo Shu ruleset and bounded `ai_tuning` guardrails.
- Implemented tooling: `tools/msq_state.py` (deterministic canonicalization + `sha256` identity → `%384` bin), `tools/msq_telemetry.py` (append-only JSONL helpers + `new_event`), `tools/msq_bandit_policy.py` (bounded per-player Thompson-sampling arm selection, persistence), and `tools/msq_demo_run.py` (small CLI tying the pieces together).
- Added `tests/test_msq_state.py` asserting canonicalization/hash/bin stability and `docs/msq_idler/README.md` describing scope and non-goals.

### Testing
- Ran `pytest -q` and unit tests passed (`5 passed`).
- Ran `npm test`, which failed because the repository does not contain a `package.json` (no Node project tests to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936227e510832587132db4e1196c4e)