### PR TITLE
config: update default phase to Phase 19 and fix health_check in sentinel_client_update.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ ARCHIVIST_PORT=5053
 SHRINE_PORT=5054
 
 # Current development phase
-CODEX_PHASE="Phase Unknown"
+CODEX_PHASE="Phase 19"

--- a/sentinel_client_update.sh
+++ b/sentinel_client_update.sh
@@ -192,7 +192,7 @@ health_check() {
         return 1
     fi
 
-    if ! response=$(curl -sS -w "%{http_code}" "http://localhost:${port}/healthz"); then
+    if ! response=$(curl -sS --connect-timeout 5 --max-time 10 -w "%{http_code}" "http://localhost:${port}/healthz"); then
         echo_log "❌ ${service} health check request failed at http://localhost:${port}/healthz"
         return 1
     fi

--- a/sentinel_client_update.sh
+++ b/sentinel_client_update.sh
@@ -45,7 +45,7 @@ CODEXJR_PORT="${CODEXJR_PORT:-5051}"
 SENTINEL_PORT="${SENTINEL_PORT:-5052}"
 ARCHIVIST_PORT="${ARCHIVIST_PORT:-5053}"
 SHRINE_PORT="${SHRINE_PORT:-5054}"
-CODEX_PHASE="${CODEX_PHASE:-Phase Unknown}"
+CODEX_PHASE="${CODEX_PHASE:-Phase 19}"
 
 # Define Sentinel Node directory
 SENTINEL_DIR="$HOME/sentinel_client"
@@ -181,6 +181,8 @@ health_check() {
     local service="$1"
     local port="$2"
     local response
+    local body
+    local http_status
 
     # NOTE: Health checks are intentionally strict: use -fsS so HTTP/connection errors
     # fail the script under `set -e`. Other curl calls in this script use -s because
@@ -189,12 +191,6 @@ health_check() {
         echo_log "❌ Invalid port: $port"
         return 1
     fi
-
-    if ! response=$(curl -fsS --connect-timeout 5 --max-time 10 "http://localhost:${port}/healthz"); then
-        echo_log "❌ ${service} health check failed at http://localhost:${port}/healthz"
-        return 1
-    local body
-    local http_status
 
     if ! response=$(curl -sS -w "%{http_code}" "http://localhost:${port}/healthz"); then
         echo_log "❌ ${service} health check request failed at http://localhost:${port}/healthz"


### PR DESCRIPTION
### Motivation
- Advance local parity defaults to `Phase 19` so new environments and fallback runtime settings reflect the requested phase update.
- Repair a malformed `health_check` function in `sentinel_client_update.sh` that caused `bash -n` to fail, restoring script syntactic validity while preserving health-check semantics.

### Description
- Updated `.env.example` to set `CODEX_PHASE="Phase 19"` so copied `.env` files default to Phase 19.
- Updated `sentinel_client_update.sh` fallback `CODEX_PHASE` to `Phase 19` to align runtime defaults with the template.
- Fixed `health_check` by declaring `local body` and `local http_status` up front and removing the stray/malformed conditional that caused a parse error, while keeping the same HTTP status and JSON-shape validation for `/healthz`.
- No ports, API shapes, or external behavior were changed other than the phase default and the shell syntax fix.

### Testing
- Ran `bash -n sentinel_client_update.sh` and it passed (syntax check OK).
- Ran `pytest -q` and all tests passed (`5 passed`).
- Ran `npm test` which is not applicable for this repo because `package.json` is absent and `npm` reported `ENOENT` (test runner unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a139cec6548325abaa25eb5247ff58)